### PR TITLE
(fix) allow newer version of babel-jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@babel/core": "7.7.5",
     "@babel/preset-env": "7.8.7",
     "babel-eslint": "10.0.3",
-    "babel-jest": "24.9.0",
+    "babel-jest": "^24.9.0",
     "cross-env": "7.0.2",
     "eslint": "6.8.0",
     "eslint-config-airbnb-base": "14.1.0",


### PR DESCRIPTION
[babel-jest](https://www.npmjs.com/package/babel-jest) is on v27.5.1 at the time of this PR. This change allows newer versions of babel-jest to be used with `jest-scss-transform`