### PR TITLE
[Bugfix] Fix Jest version 28.x.x throwing an Error for invalid return type in process handler

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,6 +5,8 @@
 
 const fs = require('fs');
 const crypto = require('crypto');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const jest = require('jest');
 
 const exportStartRegex = /\n:export.{\n*/;
 const exportEndRegex = /\n*}/;
@@ -43,3 +45,20 @@ module.exports.getCacheKey = () => (
     .update(fs.readFileSync(__filename))
     .digest('hex')
 );
+
+module.exports.makeProcessExports = (exportString) => {
+  // jest.getVersion() returns semantic version, like X.Y.Z
+  // We are only interested in the major version (the "X") in this case.
+  const [major] = jest.getVersion().split('.');
+  const majorInt = parseInt(major, 10);
+
+  if (majorInt < 27) {
+    // For jest versions 26.x.x and bellow, we are fine with just returning
+    // the exports as a string
+    return exportString;
+  }
+
+  // For jest version 27.x.x and above, we want to return an object with a
+  // "code" property, which contains an export string (see here: https://jestjs.io/docs/code-transformation)
+  return { code: exportString };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const {
   hasExports,
   isSupportedFile,
   makeExportsString,
+  makeProcessExports,
   parseExportsToObject,
 } = require('./helpers');
 
@@ -50,7 +51,10 @@ module.exports = {
     }
 
     // generate the module.exports string
-    return makeExportsString(result);
+    const exportString = makeExportsString(result);
+
+    // return the process export
+    return makeProcessExports(exportString);
   },
   getCacheKey() {
     return getCacheKey();

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const jest = require('jest');
 const sinon = require('sinon');
 
 const transformer = require('./index');
@@ -21,6 +22,10 @@ const emptyModuleString = 'module.exports = {};';
 
 describe('jest-scss-transform', () => {
   describe('transformer.process', () => {
+    beforeEach(() => {
+      sinon.restore();
+    });
+
     it('returns empty module for file extensions other than .scss', () => {
       expect(transformer.process(contentsIncorrectExt, incorrectExtFile)).toBe(emptyModuleString);
     });
@@ -40,6 +45,14 @@ describe('jest-scss-transform', () => {
     it('processes files with poorly formatted exports', () => {
       expect(transformer.process(contentsFormatting, formattingFile)).toBe(expectedParsed);
     });
+
+    it.each(['27.0.0', '27.5.2', '28.0.0', '28.0.1'])(
+      'returns object with code property for jest versions %s and above',
+      (jestVersion) => {
+        sinon.stub(jest, 'getVersion').returns(jestVersion);
+        expect(transformer.process(contentsBasic, commentsFile)).toEqual({ code: expectedParsed });
+      },
+    );
   });
 
   describe('transformer.getCacheKey', () => {


### PR DESCRIPTION
# Summary

This PR is to fix an issue with jest version 28.x.x and above where an error was thrown due to the `process()` returning a string instead of an object with the `code` property.

# Description

In this PR:
- created new `makeProcessExports` helper
- in index.js, updated return value of the `process` handler to pass the export string into the newly created helper and returns the result of that

# Related issues

This PR fixes an issue described here: https://github.com/routablehq/jest-scss-transform/issues/5