### PR TITLE
chore: update babel-jest to accept higher major versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,14 +47,14 @@
   },
   "homepage": "https://github.com/routablehq/jest-scss-transform#readme",
   "peerDependencies": {
-    "babel-jest": "^24.8.0"
+    "babel-jest": ">=24.8.0"
   },
   "devDependencies": {
     "@babel/cli": "7.8.4",
     "@babel/core": "7.7.5",
     "@babel/preset-env": "7.8.7",
     "babel-eslint": "10.0.3",
-    "babel-jest": ">=24.9.0",
+    "babel-jest": "^24.9.0",
     "cross-env": "7.0.2",
     "eslint": "6.8.0",
     "eslint-config-airbnb-base": "14.1.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@babel/core": "7.7.5",
     "@babel/preset-env": "7.8.7",
     "babel-eslint": "10.0.3",
-    "babel-jest": "^24.9.0",
+    "babel-jest": ">=24.9.0",
     "cross-env": "7.0.2",
     "eslint": "6.8.0",
     "eslint-config-airbnb-base": "14.1.0",


### PR DESCRIPTION
## Accept higher major versions of babel-jest

Currently, `jest-scss-transform` can be installed with `babel-jest` version `24.x.x`. When higher versions of `babel-jest` is installed, there is a conflicting dependency. While this can be fixed by using the `--force` or `--legacy-peer-deps` flag, it would be nice to not have to do this.

### Sample Screenshot
![Screen Shot 2022-07-04 at 11 35 56 AM](https://user-images.githubusercontent.com/25782070/177193242-b305d721-38a4-4b05-ab42-efba9811e298.png)

